### PR TITLE
fix demo: displayed incorrectly when video total time > 1h

### DIFF
--- a/app/src/main/java/com/kk/taurus/avplayer/cover/ControllerCover.java
+++ b/app/src/main/java/com/kk/taurus/avplayer/cover/ControllerCover.java
@@ -404,7 +404,7 @@ public class ControllerCover extends BaseCover implements OnTimerUpdateListener,
     public void onTimerUpdate(int curr, int duration, int bufferPercentage) {
         if(!mTimerUpdateProgressEnable)
             return;
-        if(mTimeFormat==null){
+        if(mTimeFormat==null || duration != mSeekBar.getMax()){
             mTimeFormat = TimeUtil.getFormat(duration);
         }
         mBufferPercentage = bufferPercentage;


### PR DESCRIPTION
播放在线视频的时候，初始化 ``mTimeFormat`` 的时候 ``duration`` 为 1，这时候的值并不是视频的总时长，从而导致当视频总时长超过 1 小时无法正确显示时间
https://github.com/jiajunhui/PlayerBase/blob/15f7bb48b8389cfcec7a0c07ae6eec3ca3387221/playerbase/src/main/java/com/kk/taurus/playerbase/event/EventDispatcher.java#L57-L61

https://github.com/jiajunhui/PlayerBase/blob/e98b9f3a72d764c834a701ac3564f9aecccd59ed/app/src/main/java/com/kk/taurus/avplayer/cover/ControllerCover.java#L407-L409