### PR TITLE
fix cover view position error when cover reattach to receiverGroup

### DIFF
--- a/app/src/main/java/com/kk/taurus/avplayer/cover/CloseCover.java
+++ b/app/src/main/java/com/kk/taurus/avplayer/cover/CloseCover.java
@@ -63,7 +63,12 @@ public class CloseCover extends BaseCover {
     }
 
     @Override
-    public int getCoverLevel() {
-        return levelMedium(10);
+    public int getCoverLayer() {
+        return COVER_LEVEL_MEDIUM;
+    }
+
+    @Override
+    public int getCoverPriority() {
+        return 10;
     }
 }

--- a/app/src/main/java/com/kk/taurus/avplayer/cover/CompleteCover.java
+++ b/app/src/main/java/com/kk/taurus/avplayer/cover/CompleteCover.java
@@ -112,7 +112,12 @@ public class CompleteCover extends BaseCover {
     }
 
     @Override
-    public int getCoverLevel() {
-        return levelMedium(20);
+    public int getCoverLayer() {
+        return COVER_LEVEL_MEDIUM;
+    }
+
+    @Override
+    public int getCoverPriority() {
+        return 20;
     }
 }

--- a/app/src/main/java/com/kk/taurus/avplayer/cover/ControllerCover.java
+++ b/app/src/main/java/com/kk/taurus/avplayer/cover/ControllerCover.java
@@ -475,8 +475,8 @@ public class ControllerCover extends BaseCover implements OnTimerUpdateListener,
     }
 
     @Override
-    public int getCoverLevel() {
-        return levelLow(1);
+    public int getCoverPriority() {
+        return 1;
     }
 
     @Override

--- a/app/src/main/java/com/kk/taurus/avplayer/cover/ErrorCover.java
+++ b/app/src/main/java/com/kk/taurus/avplayer/cover/ErrorCover.java
@@ -189,7 +189,7 @@ public class ErrorCover extends BaseCover {
     }
 
     @Override
-    public int getCoverLevel() {
-        return levelHigh(0);
+    public int getCoverLayer() {
+        return COVER_LEVEL_HIGH;
     }
 }

--- a/app/src/main/java/com/kk/taurus/avplayer/cover/GestureCover.java
+++ b/app/src/main/java/com/kk/taurus/avplayer/cover/GestureCover.java
@@ -217,11 +217,6 @@ public class GestureCover extends BaseCover implements OnTouchGestureListener {
     }
 
     @Override
-    public int getCoverLevel() {
-        return levelLow(0);
-    }
-
-    @Override
     public void onPlayerEvent(int eventCode, Bundle bundle) {
         switch (eventCode){
             case OnPlayerEventListener.PLAYER_EVENT_ON_VIDEO_RENDER_START:

--- a/app/src/main/java/com/kk/taurus/avplayer/cover/LoadingCover.java
+++ b/app/src/main/java/com/kk/taurus/avplayer/cover/LoadingCover.java
@@ -78,7 +78,12 @@ public class LoadingCover extends BaseCover {
     }
 
     @Override
-    public int getCoverLevel() {
-        return levelMedium(1);
+    public int getCoverLayer() {
+        return COVER_LEVEL_MEDIUM;
+    }
+
+    @Override
+    public int getCoverPriority() {
+        return 1;
     }
 }

--- a/exoplayer/build.gradle
+++ b/exoplayer/build.gradle
@@ -34,6 +34,6 @@ dependencies {
     api 'com.google.android.exoplayer:exoplayer-dash:2.11.1'
     api 'com.google.android.exoplayer:exoplayer-hls:2.11.1'
     api 'com.google.android.exoplayer:exoplayer-smoothstreaming:2.11.1'
-    api 'com.kk.taurus.playerbase:playerbase:3.3.6'
-//    api project(':playerbase')
+//    api 'com.kk.taurus.playerbase:playerbase:3.3.6'
+    api project(':playerbase')
 }

--- a/ijkplayer/build.gradle
+++ b/ijkplayer/build.gradle
@@ -31,6 +31,6 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     api 'tv.danmaku.ijk.media:ijkplayer-java:0.8.8'
-    api 'com.kk.taurus.playerbase:playerbase:3.3.6'
-//    api project(':playerbase')
+//    api 'com.kk.taurus.playerbase:playerbase:3.3.6'
+    api project(':playerbase')
 }

--- a/playerbase/src/main/java/com/kk/taurus/playerbase/receiver/AbsCoverContainer.java
+++ b/playerbase/src/main/java/com/kk/taurus/playerbase/receiver/AbsCoverContainer.java
@@ -40,17 +40,17 @@ public abstract class AbsCoverContainer implements ICoverStrategy {
     }
 
     @Override
-    public void addCover(BaseCover cover) {
+    public void addCover(BaseCover cover, boolean insert) {
         onCoverAdd(cover);
         if(isAvailableCover(cover)){
             mCovers.add(cover);
-            onAvailableCoverAdd(cover);
+            onAvailableCoverAdd(cover, insert);
         }
     }
 
     protected abstract void onCoverAdd(BaseCover cover);
 
-    protected abstract void onAvailableCoverAdd(BaseCover cover);
+    protected abstract void onAvailableCoverAdd(BaseCover cover, boolean insert);
 
     @Override
     public void removeCover(BaseCover cover) {

--- a/playerbase/src/main/java/com/kk/taurus/playerbase/receiver/BaseCover.java
+++ b/playerbase/src/main/java/com/kk/taurus/playerbase/receiver/BaseCover.java
@@ -18,7 +18,6 @@ package com.kk.taurus.playerbase.receiver;
 
 import android.content.Context;
 import android.os.Bundle;
-import androidx.annotation.IntRange;
 import android.view.View;
 
 import com.kk.taurus.playerbase.assist.InterEvent;
@@ -35,6 +34,7 @@ public abstract class BaseCover extends BaseReceiver implements
     public BaseCover(Context context) {
         super(context);
         mCoverView = onCreateCoverView(context);
+        mCoverView.setTag(getCoverPriority());
         mCoverView.addOnAttachStateChangeListener(this);
     }
 
@@ -129,47 +129,27 @@ public abstract class BaseCover extends BaseReceiver implements
     protected abstract View onCreateCoverView(Context context);
 
     @Override
-    public int getCoverLevel() {
+    public final int getCoverLevel() {
+        return makeLevelSpec(getCoverLayer(), getCoverPriority());
+    }
+
+    /**
+     * MODE_MASK  -->  11000000
+     * ~MODE_MASK  -->  00111111
+     * level & MODE_MASK  -->  01000000 & 11000000 = 01000000  这个操作是取高两位信息
+     * priority & ~MODE_MASK  -->  00000011 & 00111111  取低两位信息
+     * (level & MODE_MASK) | (priority & ~MODE_MASK)  高低两位结合
+     */
+    private int makeLevelSpec(int mode, int priority){
+        return (mode & MODE_MASK) | (priority & ~MODE_MASK);
+    }
+
+    public @CoverLevelSpec int getCoverLayer(){
         return ICover.COVER_LEVEL_LOW;
     }
 
-    /**
-     * setting the priority in COVER_LEVEL_LOW.
-     * The high priority cover will be placed above,
-     * otherwise the lower priority will be placed below.
-     *
-     * @param priority range from 0-31
-     * @return
-     */
-    protected final int levelLow(@IntRange(from = 0, to = 31)int priority){
-        return levelPriority(ICover.COVER_LEVEL_LOW, priority);
-    }
-
-    /**
-     * setting the priority in COVER_LEVEL_MEDIUM.
-     * The high priority cover will be placed above,
-     * otherwise the lower priority will be placed below.
-     *
-     * @param priority range from 0-31
-     * @return
-     */
-    protected final int levelMedium(@IntRange(from = 0, to = 31)int priority){
-        return levelPriority(ICover.COVER_LEVEL_MEDIUM, priority);
-    }
-
-    /**
-     * setting the priority in COVER_LEVEL_HIGH.
-     * The high priority cover will be placed above,
-     * otherwise the lower priority will be placed below.
-     *
-     * @param priority range from 0-31
-     * @return
-     */
-    protected final int levelHigh(@IntRange(from = 0, to = 31)int priority){
-        return levelPriority(ICover.COVER_LEVEL_HIGH, priority);
-    }
-
-    private int levelPriority(int level, int priority){
-        return level + (priority%LEVEL_MAX);
+    @Override
+    public int getCoverPriority() {
+        return 0;
     }
 }

--- a/playerbase/src/main/java/com/kk/taurus/playerbase/receiver/BaseLevelCoverContainer.java
+++ b/playerbase/src/main/java/com/kk/taurus/playerbase/receiver/BaseLevelCoverContainer.java
@@ -43,7 +43,7 @@ public abstract class BaseLevelCoverContainer extends AbsCoverContainer {
     }
 
     @Override
-    protected void onAvailableCoverAdd(BaseCover cover) {
+    protected void onAvailableCoverAdd(BaseCover cover, boolean insert) {
         PLog.d(TAG,"on available cover add : now count = " + getCoverCount());
     }
 

--- a/playerbase/src/main/java/com/kk/taurus/playerbase/receiver/DefaultLevelCoverContainer.java
+++ b/playerbase/src/main/java/com/kk/taurus/playerbase/receiver/DefaultLevelCoverContainer.java
@@ -67,19 +67,40 @@ public class DefaultLevelCoverContainer extends BaseLevelCoverContainer {
     }
 
     @Override
-    protected void onAvailableCoverAdd(BaseCover cover) {
-        super.onAvailableCoverAdd(cover);
-        int level = cover.getCoverLevel();
-        if(level < ICover.COVER_LEVEL_MEDIUM){
-            mLevelLowCoverContainer.addView(cover.getView(),getNewMatchLayoutParams());
-            PLog.d(TAG, "Low Level Cover Add : level = " + level);
-        }else if(level < ICover.COVER_LEVEL_HIGH){
-            mLevelMediumCoverContainer.addView(cover.getView(),getNewMatchLayoutParams());
-            PLog.d(TAG, "Medium Level Cover Add : level = " + level);
-        }else{
-            mLevelHighCoverContainer.addView(cover.getView(),getNewMatchLayoutParams());
-            PLog.d(TAG, "High Level Cover Add : level = " + level);
+    protected void onAvailableCoverAdd(BaseCover cover, boolean insert) {
+        super.onAvailableCoverAdd(cover, insert);
+        int mode = cover.getCoverLayer();
+        ViewGroup viewGroup;
+        switch (mode) {
+            default:
+            case ICover.COVER_LEVEL_LOW:
+                viewGroup = mLevelLowCoverContainer;
+                break;
+            case ICover.COVER_LEVEL_MEDIUM:
+                viewGroup = mLevelLowCoverContainer;
+                break;
+            case ICover.COVER_LEVEL_HIGH:
+                viewGroup = mLevelHighCoverContainer;
+                break;
         }
+        addView(viewGroup, cover, insert);
+    }
+
+    private void addView(ViewGroup parent, BaseCover cover, boolean insert) {
+        int priority = cover.getCoverPriority();
+        int childCount = parent.getChildCount();
+        int insetPosition = -1;
+        if (insert) {
+            for (int i = 0; i < childCount; i++) {
+                int viewPriority = (int) parent.getChildAt(i).getTag();
+                if (priority < viewPriority) {
+                    insetPosition = i;
+                    break;
+                }
+            }
+            PLog.d(TAG, "insert position " + insetPosition);
+        }
+        parent.addView(cover.getView(), insetPosition);
     }
 
     @Override

--- a/playerbase/src/main/java/com/kk/taurus/playerbase/receiver/ICover.java
+++ b/playerbase/src/main/java/com/kk/taurus/playerbase/receiver/ICover.java
@@ -18,25 +18,33 @@ package com.kk.taurus.playerbase.receiver;
 
 import android.view.View;
 
+import androidx.annotation.IntDef;
+import androidx.annotation.IntRange;
+
 /**
  * Created by Taurus on 2017/3/24.
  */
 
 public interface ICover {
 
-    //the max cover priority value per level container.
-    int LEVEL_MAX = 1 << 5;
+    int MODE_SHIFT = 6;
+    int MODE_MASK = 0x3 << MODE_SHIFT;
 
     //level low container start value.
-    int COVER_LEVEL_LOW     = 0;
+    int COVER_LEVEL_LOW     = 0 << MODE_SHIFT;
 
     //level medium container start value.
-    int COVER_LEVEL_MEDIUM  = 1 << 5;
+    int COVER_LEVEL_MEDIUM  = 1 << MODE_SHIFT;
 
     //level high container start value.
-    int COVER_LEVEL_HIGH    = 1 << 6;
+    int COVER_LEVEL_HIGH    = 2 << MODE_SHIFT;
+
+    @IntDef({COVER_LEVEL_LOW, COVER_LEVEL_MEDIUM, COVER_LEVEL_HIGH})
+    public @interface CoverLevelSpec {}
 
     void setCoverVisibility(int visibility);
     View getView();
     int getCoverLevel();
+    @CoverLevelSpec int getCoverLayer();
+    @IntRange(from = 0, to = 63) int getCoverPriority();
 }

--- a/playerbase/src/main/java/com/kk/taurus/playerbase/receiver/ICoverStrategy.java
+++ b/playerbase/src/main/java/com/kk/taurus/playerbase/receiver/ICoverStrategy.java
@@ -24,7 +24,7 @@ import android.view.ViewGroup;
 
 public interface ICoverStrategy {
 
-    void addCover(BaseCover cover);
+    void addCover(BaseCover cover, boolean insert);
     void removeCover(BaseCover cover);
     void removeAllCovers();
     boolean isContainsCover(BaseCover cover);

--- a/playerbase/src/main/java/com/kk/taurus/playerbase/widget/SuperContainer.java
+++ b/playerbase/src/main/java/com/kk/taurus/playerbase/widget/SuperContainer.java
@@ -208,7 +208,7 @@ public class SuperContainer extends FrameLayout implements OnTouchGestureListene
         mReceiverGroup.forEach(new IReceiverGroup.OnLoopListener() {
             @Override
             public void onEach(IReceiver receiver) {
-                attachReceiver(receiver);
+                attachReceiver(receiver, false);
             }
         });
         //add a receiver group change listener, dynamic attach a receiver
@@ -222,7 +222,7 @@ public class SuperContainer extends FrameLayout implements OnTouchGestureListene
             new IReceiverGroup.OnReceiverGroupChangeListener() {
         @Override
         public void onReceiverAdd(String key, IReceiver receiver) {
-            attachReceiver(receiver);
+            attachReceiver(receiver, true);
         }
         @Override
         public void onReceiverRemove(String key, IReceiver receiver) {
@@ -232,14 +232,14 @@ public class SuperContainer extends FrameLayout implements OnTouchGestureListene
 
     //attach receiver, bind receiver event listener
     // and add cover container if it is a cover instance.
-    private void attachReceiver(IReceiver receiver){
+    private void attachReceiver(IReceiver receiver, boolean insert){
         //bind the ReceiverEventListener for receivers connect.
         receiver.bindReceiverEventListener(mInternalReceiverEventListener);
         receiver.bindStateGetter(mStateGetter);
         if(receiver instanceof BaseCover){
             BaseCover cover = (BaseCover) receiver;
             //add cover view to cover strategy container.
-            mCoverStrategy.addCover(cover);
+            mCoverStrategy.addCover(cover, insert);
             PLog.d(TAG, "on cover attach : " + cover.getTag() + " ," + cover.getCoverLevel());
         }
     }


### PR DESCRIPTION
这个pull request直接改动了关键方法，而且我的测试不完全。你看一下是什么问题即可。谨慎合并
问题：
例，Acover 的level 是low 1
Bcover的level是low 2
如果移除A，再添加A，A会覆盖在B上面。违背cover层级概念
